### PR TITLE
getFigH: add grid setup within this function

### DIFF
--- a/getFigH.m
+++ b/getFigH.m
@@ -102,6 +102,12 @@ for fig=1:numel(figH)
     end
     if caxis
         axH(fig) = axes(figH(fig));
+        axH(fig).XGrid = 'on';
+        axH(fig).YGrid = 'on';
+        axH(fig).ZGrid = 'on';
+        axH(fig).XMinorGrid = 'on';
+        axH(fig).YMinorGrid = 'on';
+        axH(fig).ZMinorGrid = 'on';
     end
 end
 


### PR DESCRIPTION
- only when requesting axis handles are they created within this function
  - otherwise they are created when calling non-primtive plotting functions (plot, surf, etc.)
- so when axis handles are requested, we assume the following plot commands are primitive (line, surface, etc..)
  - primtive plot functions assume an existing axis handle, and need to provided with it instead of the figure handle
  - primitive plotting functions don't overwrite any axis handle properties
  - this means we can set axis properties like grid in this function