### PR TITLE
[CS][feat] allow multiple env variables

### DIFF
--- a/getPathFromEnv.m
+++ b/getPathFromEnv.m
@@ -2,24 +2,49 @@ function [fsPath] = getPathFromEnv(type)
 %GETDIRPATHFROMENV Returns a path from environment variable at the root of the invoking script
 %   input: empty
 %   output: filesystem path as char
-%   
+%
 %   Usage examples: fsPath = getPathFromEnv();
-%   
+%
 
-envExists = isfile('.env');                                 % check if environmental variable is set
+version = '0.1';                % version of the environmental variable file
+envExists = isfile('.env');     % check if environmental variable is set
+caller = dbstack();             % get the function call stack
+caller = caller(2).name;        % get the name of the function that invoked getPathFromEnv()
 
-if envExists                                                % read path from environment varibale if set
-    fID = fopen(fullfile(cd,'.env'),'r');                   % open the file containing the env variable
-    envPath = fscanf(fID,'%c');                             % parse the file contents, returns path stored in the env variable
-else                                                        % create the env variable if not found, store the desired default path
-    envPath = uigetdir("C:\",'Define default directory');   % open folder selection dialog box
-    if isnumeric(envPath)
-        error('User abort during selection of default path.\n');
+%% look for and read the environmental variable
+if envExists
+    % read path from environment varibale if set
+    [isOld, envPath] = isOldstyleEnv();
+    if isOld
+        createEnvXML(caller,envPath, version);
+    else
+        envs = readstruct(fullfile(cd,'.env'),"FileType","xml");
+        numberCallers = numel(envs.env);
+        callers = strings(1,numberCallers);
+        for env = 1:numel(envs.env)
+            callers(env) = envs.env(env).caller;
+        end
+        callerIndex = matches(callers,caller);
+        if ~any(callerIndex)
+            % if caller is not in the env, add it
+            envPath = selectEnvPath();
+            envs.env(end+1).caller = caller;
+            envs.env(end).path = envPath;
+            writestruct(envs,fullfile(cd,'.env'),"FileType","xml");
+        else
+            % the caller was found in the env, return the path
+            envPath = envs.env(callerIndex).path;
+        end
     end
-    fID = fopen('.env','w');                                % create the environmental variable in the root of the invoking script
-    fprintf(fID,'%s',envPath);                              % write the desired default path to the env variable
+
+else
+    % create the env variable if not found, store the desired default path
+    envPath = selectEnvPath();
+    createEnvXML(caller, envPath, version);
 end
 
+%% display the folder/file selection dialog
+% return either a user specified folder or file
 switch type
     case 'folder'
         fsPath = uigetdir(envPath,'Select source directory');   % open the folder selection dialog box
@@ -29,7 +54,35 @@ switch type
         fsPath = fullfile(path,filename);
 end
 
-status = fclose(fID);                                       % close the file containing the environment varibale
-
 end
 
+function [isTxtFlag,path] = isOldstyleEnv()
+% returns false if the env is an XML file
+% returns true and the path if file is not XML
+isTxtFlag = true;
+fID = fopen(fullfile(cd,'.env'),'r');               % open the file containing the env variable
+path = fscanf(fID,'%c');                            % parse the file contents, returns path stored in the env variable
+if startsWith(path,'<?xml version="1.0"')        % check for beginning of XML file
+    isTxtFlag = false;
+    path = [];                                      % return empty path, need to identify the path through different means
+end
+fclose(fID);                                        % close the file
+end
+
+function createEnvXML(caller, path, version)
+% create an XML env from a provided caller and path value
+env = struct();
+env.caller = caller;
+env.path = path;
+envs.env = env;
+envs.version = version;
+writestruct(envs,fullfile(cd,'.env'),"FileType","xml","StructNodeName","environmentalVariables");
+end
+
+function envPath = selectEnvPath()
+% open folder selection dialoge, to select the path to be stored in the env
+envPath = uigetdir("C:\",'Define default directory');   % open folder selection dialog box
+if isnumeric(envPath)
+    error('User abort during selection of default path.\n');
+end
+end

--- a/getPathFromEnv.m
+++ b/getPathFromEnv.m
@@ -19,9 +19,9 @@ if envExists
         createEnvXML(caller,envPath, version);
     else
         envs = readstruct(fullfile(cd,'.env'),"FileType","xml");
-        numberCallers = numel(envs.env);
-        callers = strings(1,numberCallers);
-        for env = 1:numel(envs.env)
+        numberEnvs = numel(envs.env);
+        callers = strings(1,numberEnvs);
+        for env = 1:numberEnvs
             callers(env) = envs.env(env).caller;
         end
         callerIndex = matches(callers,caller);

--- a/getPathFromEnv.m
+++ b/getPathFromEnv.m
@@ -13,11 +13,15 @@ caller = caller(2).name;        % get the name of the function that invoked getP
 
 %% look for and read the environmental variable
 if envExists
-    % read path from environment varibale if set
+    % an environment varibale was found, read path from it
     [isOld, envPath] = isOldstyleEnv();
     if isOld
+        % the env variable was formatted in the oldstyle (plain text)
+        % create a new env variable (overwriting the old one) in the new format
         createEnvXML(caller,envPath, version);
     else
+        % the env varibale is well formed
+        % read from it the desired path
         envs = readstruct(fullfile(cd,'.env'),"FileType","xml");
         numberEnvs = numel(envs.env);
         callers = strings(1,numberEnvs);
@@ -26,7 +30,8 @@ if envExists
         end
         callerIndex = matches(callers,caller);
         if ~any(callerIndex)
-            % if caller is not in the env, add it
+            % the caller was not found in the env
+            % add it and store the desired path
             envPath = selectEnvPath();
             newEnvIndex = numberEnvs+1;
             envs.env(newEnvIndex).caller = caller;
@@ -39,7 +44,8 @@ if envExists
     end
 
 else
-    % create the env variable if not found, store the desired default path
+    % an env variable was not found, create it and store the desired
+    % default path in it
     envPath = selectEnvPath();
     createEnvXML(caller, envPath, version);
 end

--- a/getPathFromEnv.m
+++ b/getPathFromEnv.m
@@ -28,8 +28,9 @@ if envExists
         if ~any(callerIndex)
             % if caller is not in the env, add it
             envPath = selectEnvPath();
-            envs.env(end+1).caller = caller;
-            envs.env(end).path = envPath;
+            newEnvIndex = numberEnvs+1;
+            envs.env(newEnvIndex).caller = caller;
+            envs.env(newEnvIndex).path = envPath;
             writestruct(envs,fullfile(cd,'.env'),"FileType","xml");
         else
             % the caller was found in the env, return the path


### PR DESCRIPTION
- in order to use multiple environmental variables in one directory, the envs need to be stored in a structured file
  - XML was chosen due to simplicity and readability
- the function supports
  - multiple callers per directory
  - reading an old style environmental variable and convert it
  - adding a new caller to the env