### PR TITLE
getFileList: safe abort

### DIFF
--- a/getFileList.m
+++ b/getFileList.m
@@ -9,14 +9,24 @@ function [filelist, filetable] = getFileList(fsPath,mode,extensions)
 %   getFileList(fsPath,'include',{'txt','ldx'})
 %   getFileList(fsPath,'exclude','.stignore')
 
-% if the shortcut call is used use the default mode 'all'
-if nargin==1
-    mode = 'all';
-end
 % if there is more than one output, create a table of the contents
 createTable = false;
 if nargout > 1
     createTable = true;
+end
+
+% safe abort in case the file selection dialog was aborted by user
+if ~logical(fsPath)
+    filelist = 0;
+    if createTable
+        filetable = 0;
+    end
+    return;
+end
+
+% if the shortcut call is used use the default mode 'all'
+if nargin==1
+    mode = 'all';
 end
 
 dircontents = dir(fsPath);                  % get the contents of the directory

--- a/isBetween.m
+++ b/isBetween.m
@@ -1,11 +1,30 @@
-function [state] = isBetween(signal,min,max)
+function [state] = isBetween(signal, interval, width)
 %ISBETWEEN returns true when signal is between min and max
-%   Detailed explanation goes here
+%   interval:   interval of interest
+%   width:      width of the detection band in case of scalar interval
+%
+%   interval:
+%       vector:             [lower upper]
+%       scalar w width:     [center] (+/- width)
+%       scalar w/o width:   [-value value]
+
+if isscalar(interval)
+    if nargin < 3
+        min = -1 * interval;
+        max =      interval;
+    else
+        min = interval - width;
+        max = interval + width;
+    end
+else
+    min = interval(1);
+    max = interval(2);
+end
 
 state1 = signal > min;
 state2 = signal < max;
 
-state = and(state1,state2);
+state = and(state1, state2);
 
 end
 

--- a/isBetween.m
+++ b/isBetween.m
@@ -1,0 +1,11 @@
+function [state] = isBetween(signal,min,max)
+%ISBETWEEN returns true when signal is between min and max
+%   Detailed explanation goes here
+
+state1 = signal > min;
+state2 = signal < max;
+
+state = and(state1,state2);
+
+end
+


### PR DESCRIPTION
### Why
- the function crashed when the user canceled the file selection dialog without prior error handling

### in depth
- detect whether provided filesystem path is a boolean
- detect what variables we need to return
- return boolean false for all requested return variables
- this allows error handling in the invoking program