### PR TITLE
[CS][fix] loadMotec: synchronize signals with differing timestamps common timeline

### DIFF
--- a/loadMotec.m
+++ b/loadMotec.m
@@ -1,40 +1,113 @@
-function [signals,dT] = loadMotec(sourcePath)
+function [signals] = loadMotec(sourcePath)
 %LOADMOTEC loads Motec data into timetable
 %   sourcePath:     path to the Motec exportet .mat file
 %
-%   returnes:
+%   returns:
 %   signals:        timetable, contains metadata in var.Properties.UserData
-%   dT:             duration, average timestep of signals <- this may be
-%   removed. a timetable already has a field 'timestep' which seems to
-%   return the same result
 
 data = load(sourcePath);                                                    % load file from disk
 
 fldnames = fieldnames(data);                                                % get names of signals in file
-nSamples = length(data.(fldnames{1}).Time);                                 % get the number of samples in file
 nVariables = numel(fldnames);                                               % get the number of signals in file
-timestamps = data.(fldnames{1}).Time - min(data.(fldnames{1}).Time);        % shift time to begin sampling @ t=0, this should be selectable using an argument
 
-signals = timetable('Size',[nSamples nVariables],...                        % init the output table
-    'VariableTypes',repmat({'double'},[nVariables,1]),...
-    'VariableNames',fldnames,...
-    'RowTimes',duration(0, 0, timestamps));
-
+nSamples = NaN(nVariables,1);                                               % list of sample counts per signal
 for field=1:nVariables
-    signals{:,field} = data.(fldnames{field}).Value';                       % restructure signals into timetable
+    nSamples(field) = numel(data.(fldnames{field}).Time');
 end
 
-dT = (signals.Time(end) - signals.Time(1))/height(signals);                 % calculate the timestep
-% the timesteps in the MoTeC exportet files aren't constant
-% for some applications it might be required to have a constant timestamp
-% for such cases, this timestep as a average value may be used
-signals.Time.Format = 's';                                                  % show the timestamp as ss:SSS
+nSamples_bin = unique(nSamples);                                            % get a list of unique sample counts
 
-% add metadata to the return value for external use
-signals.Properties.UserData.dT = dT;
+% create bins for signals of same count
+apped_table = false;
+tic
+for bin = 1:numel(nSamples_bin)
+    signals_in_bin = find(nSamples==nSamples_bin(bin));                     % get a list of indices of signals in a bin of same sample count
+    nSignals_in_bin(bin) = numel(signals_in_bin);                           % number of signals in each bin
+    
+    % get matching timestamps for the signals in the current bin
+    result = compareTimestamps(data, fldnames(signals_in_bin), nSamples_bin(bin));
+
+    if all(result)                                                          % all timestamps match: signals can be placed in a table directly
+        temp_table = signals2table(data, fldnames(signals_in_bin), nSamples_bin(bin));
+    else                                                                    % some timestamps are mismatch: further processing required
+        % we group the signals into bins again
+        % all signals matching with the first signal of the bin will be placed in a table
+        binsRemaining = true;
+        append_subtable = false;
+
+        while binsRemaining
+            % get indices of signals currently matching the timestamp bin
+            signals_in_subBin = signals_in_bin(result);
+            % create a table from these signals
+            temp_table_subBin = signals2table(data, fldnames(signals_in_subBin), nSamples_bin(bin));
+            % either this table is the basis for a syncronisation operation
+            % next time around or it needs to be syncronised
+            if append_subtable                                              % the table needs to be syncronised into an existing table
+                temp_table = synchronize(temp_table, temp_table_subBin, 'union', 'previous');
+            else                                                            % this table is the first for this sub bin operation
+                temp_table = temp_table_subBin;
+                append_subtable = true;
+            end
+            signals_in_bin = signals_in_bin(~result);                       % remove processed signals
+            if isempty(signals_in_bin)                                      % check if there are any more timestamps bins
+                binsRemaining = false;                                      % end operation
+            else                                                            % look for new timestamp bins
+                result = compareTimestamps(data, fldnames(signals_in_bin), nSamples_bin(bin));
+            end
+        end
+    end
+
+    % our table is either the basis for the output table or it needs to
+    % syncronised into the output table
+    if apped_table
+        signals = synchronize(signals, temp_table, 'union', 'previous');
+    else
+        signals = temp_table;
+        apped_table = true;
+    end
+end
+toc
+
+signals.Time.Format = 's';                                                  % show the timestamp as ss:SSS
 
 [~,fName] = fileparts(sourcePath);
 signals.Properties.UserData.srcFileName = fName;
 signals.Properties.UserData.srcFilePath = sourcePath;
 
+end
+
+function temp_table = signals2table(data, signal_names, nSamples)
+% this function creates a timetable from a list of signals
+
+nSignals = numel(signal_names);                                             % number of signals, used to preallocate the matrix
+signaltemp = NaN(nSamples, nSignals);                                       % sample count, used to preallocate the matrix
+for signal = 1:nSignals                                                     % loop over all signals, enter into the matrix
+    signaltemp(:,signal) = data.(signal_names{signal}).Value';
+end
+time = duration(0, 0, data.(signal_names{signal}).Time');                   % create the timestamp vector
+temp_table = array2timetable(signaltemp, 'RowTimes', time, 'VariableNames', signal_names);  % create table from time vector and signal matrix
+
+end
+
+function result = compareTimestamps(data, signals, nSamples)
+% this function returns a logical value for each signal
+% it's true, when a signals timesteps match with the timesteps of the first
+% signal in the list
+% for the first signal it returns true (matches with itself)
+
+result = true;
+
+nSignals = numel(signals);
+
+if nSignals < 2                                                             % end operation, when there is only one signal
+    return
+end
+
+timestamps = NaN(nSamples, nSignals);                                       % store the timestamps for each signal of the bin
+timestamps(:,1) = data.(signals{1}).Time';                                  % preload the array with the main timestamps we comapre against
+
+for signal = 2:nSignals                                                     % loop over all signals in the bin
+    timestamps(:, signal) = data.(signals{signal}).Time';                   % get timestamps of the current signal
+    result(signal) = all(timestamps(:,1) == timestamps(:,signal));
+end
 end

--- a/loadMotec.m
+++ b/loadMotec.m
@@ -19,10 +19,15 @@ SampleCount_bin = unique(nSamples);                                         % ge
 
 % create bins for signals of same count
 apped_table = false;
+nSignals_ignored = 0;
 tic
 for bin = 1:numel(SampleCount_bin)
+    
     signals_in_bin = find( nSamples == SampleCount_bin(bin) );              % get a list of indices of signals in a bin of same sample count
-
+    if SampleCount_bin(bin) == 0                                            % skip signals with a sample count of zero
+        nSignals_ignored = numel(signals_in_bin);                           % store the number of signals ignored
+        continue
+    end
     % test for matching timestamps of the signals in the current bin
     result = compareTimestamps(data, fldnames(signals_in_bin), SampleCount_bin(bin));
 
@@ -69,10 +74,10 @@ signals.Properties.UserData.srcFileName = fName;
 signals.Properties.UserData.srcFilePath = sourcePath;
 
 % validation
-if nVariables ~= width(signals)
+if nVariables ~= width(signals) + nSignals_ignored
     error("signals were dropped in the operation")
 end
-s
+
 end
 
 function temp_table = signals2table(data, signal_names, nSamples)


### PR DESCRIPTION
### why

- closes #20 
- closes #26 

### in depth

- it is possible to load motec files with signals of differing sample counts
- the timestep calculation discussed in #20 is assumed to work because we cannot calculate this as simple anymore
  - the calculation was based on the delta between the highest and smallest timestep
  - this was then divided by the number of samples
  - this however is imprecise, when there are gaps in the timeline