### PR TITLE
[CS][feat] `isBetween` allow vector as mask

### DIFF
--- a/isBetween.m
+++ b/isBetween.m
@@ -1,4 +1,4 @@
-function [state] = isBetween(signal, interval, width)
+function [state] = isBetween(signal, interval, interval_width)
 %ISBETWEEN returns true when signal is between min and max
 %   interval:   interval of interest
 %   width:      width of the detection band in case of scalar interval
@@ -8,17 +8,17 @@ function [state] = isBetween(signal, interval, width)
 %       scalar w width:     [center] (+/- width)
 %       scalar w/o width:   [-value value]
 
-if isscalar(interval)
+if width(interval)==1           % scalars or single column vectors
     if nargin < 3
         min = -1 * interval;
         max =      interval;
     else
-        min = interval - width;
-        max = interval + width;
+        min = interval - interval_width;
+        max = interval + interval_width;
     end
-else
-    min = interval(1);
-    max = interval(2);
+else                            % vectors, or multi column vectors
+    min = interval(:,1);
+    max = interval(:,2);
 end
 
 state1 = signal > min;


### PR DESCRIPTION
### why

- allow intervals to be vectors of same length as the signal
- closes #33 

### in depth

- the interval matrix needs to be Nx2
  - N being the length of the signal
  - 2 columns are required for lower and upper bounds
- explicitely set the required size for non signal based intervals to be single row data types
- rename the variabel `width` to `interval_width`
  - there was an overloading of funciton names, and the `width()` function is now used in this function